### PR TITLE
fix: include dist/ in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "polymarket-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Polymarket prediction market sentiment for AI trading agents",
   "bin": { "polymarket": "./dist/index.js" },
   "type": "module",
+  "files": [
+    "dist",
+    "skill",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/raybooysen/polymarket-agent"


### PR DESCRIPTION
## Problem

`polymarket-cli@0.1.0` crashes on install because the published tarball is missing compiled files from `dist/`.

**Root cause:** No `files` field in `package.json`, so npm falls back to `.gitignore` which excludes `dist/`. Only `dist/index.js` was included (via the `bin` reference).

## Fix

- Add explicit `files` field: `dist/`, `skill/`, `README.md`, `LICENSE`
- This also cleans up the tarball — no more `src/`, `tests/`, or CI configs shipped to npm
- Bump to `0.1.1` for republish

Package size drops from 15.6 kB → 13.1 kB while actually shipping the files that matter.

Closes #2