### PR TITLE
fix: search and events return stale 2020 data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymarket-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Polymarket prediction market sentiment for AI trading agents",
   "bin": { "polymarket": "./dist/index.js" },
   "type": "module",

--- a/src/api/gamma.ts
+++ b/src/api/gamma.ts
@@ -30,12 +30,16 @@ export async function getMarkets(params?: {
 export async function getEvents(params?: {
   limit?: number;
   active?: boolean;
+  closed?: boolean;
   order?: string;
+  ascending?: boolean;
 }): Promise<GammaEvent[]> {
   const searchParams = new URLSearchParams();
   if (params?.limit !== undefined) searchParams.set('limit', String(params.limit));
   if (params?.active !== undefined) searchParams.set('active', String(params.active));
+  if (params?.closed !== undefined) searchParams.set('closed', String(params.closed));
   if (params?.order) searchParams.set('order', params.order);
+  if (params?.ascending !== undefined) searchParams.set('ascending', String(params.ascending));
 
   const query = searchParams.toString();
   const url = `${BASE_URL}/events${query ? `?${query}` : ''}`;
@@ -47,10 +51,16 @@ export async function getEvents(params?: {
   }
 }
 
-export async function searchMarkets(query: string, limit?: number): Promise<GammaMarket[]> {
+export async function searchMarkets(query: string, limit?: number, activeOnly: boolean = true): Promise<GammaMarket[]> {
   const searchParams = new URLSearchParams();
   searchParams.set('_q', query);
   if (limit !== undefined) searchParams.set('limit', String(limit));
+  if (activeOnly) {
+    searchParams.set('active', 'true');
+    searchParams.set('closed', 'false');
+  }
+  searchParams.set('order', 'volume24hr');
+  searchParams.set('ascending', 'false');
 
   const url = `${BASE_URL}/markets?${searchParams.toString()}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ program
       const pretty = program.opts().pretty as boolean;
       const events = await getEvents({
         active: true,
+        closed: false,
+        order: 'volume24hr',
+        ascending: false,
         limit: parseInt(opts.limit as string, 10),
       });
       process.stdout.write(formatOutput(events, pretty) + '\n');

--- a/tests/integration/gamma.integration.test.ts
+++ b/tests/integration/gamma.integration.test.ts
@@ -43,4 +43,28 @@ describe('Gamma API Integration', () => {
       expect(markets[i - 1].volume24hr).toBeGreaterThanOrEqual(markets[i].volume24hr);
     }
   });
+
+  it('search returns only active non-closed markets', { timeout: 30000 }, async () => {
+    const results = await searchMarkets('iran', 5);
+    expect(results.length).toBeGreaterThan(0);
+    for (const market of results) {
+      expect(market.closed).toBe(false);
+    }
+  });
+
+  it('search results sorted by volume', { timeout: 30000 }, async () => {
+    const results = await searchMarkets('bitcoin', 10);
+    expect(results.length).toBeGreaterThan(0);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].volume24hr).toBeGreaterThanOrEqual(results[i].volume24hr);
+    }
+  });
+
+  it('events with closed=false returns only active events', { timeout: 30000 }, async () => {
+    const events = await getEvents({ limit: 5, active: true, closed: false, order: 'volume24hr', ascending: false });
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.closed).toBe(false);
+    }
+  });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -90,6 +90,7 @@ function runCli(args: string): string {
     return execSync(`${TSX} ${CLI_PATH} ${args}`, {
       encoding: 'utf-8',
       timeout: 30000,
+      maxBuffer: 10 * 1024 * 1024,
       cwd: path.resolve('.'),
     });
   } catch (err) {


### PR DESCRIPTION
## Problem

`polymarket search` and `polymarket events` return ancient 2020-2021 markets (Biden COVID, Airbnb IPO, old NFL games) instead of current active markets.

## Root cause

Same class of bug as #5 (which fixed `sentiment`). The Gamma API returns all markets including historical ones. Without `closed=false` and volume sorting, stale data fills the results.

## Fix

- **search**: Added `active=true`, `closed=false`, sorted by `volume24hr` descending
- **events**: Added `closed=false` param support, sorted by `volume24hr` descending

## Result

```bash
# Before
polymarket search 'iran' → 'Will Joe Biden get Coronavirus?' (2020)

# After  
polymarket search 'iran' → 'US forces enter Iran by March 31?' ($3.1M vol)
```

## Tests

65 total (3 new integration tests):
- Search returns only active non-closed markets ✓
- Search results sorted by volume ✓  
- Events with closed=false returns only active events ✓

Bumps to 0.2.1. Closes #6